### PR TITLE
Add .fips-template.yaml to opt into fips-agents patch flow

### DIFF
--- a/.fips-template.yaml
+++ b/.fips-template.yaml
@@ -1,0 +1,65 @@
+# fips-agents-cli template manifest.
+#
+# This file declares which paths in the code-sandbox template are managed
+# by the template (and so should be offered as patches by `fips-agents
+# patch`) and which belong to the user. The CLI reads this file from
+# the repo root after cloning, before computing drift in
+# `fips-agents patch check`.
+#
+# Without this manifest, `fips-agents patch` does not work for sandbox
+# projects — the CLI raises a clean error pointing the user here. The
+# presence of this file is what opts the sandbox template into the
+# patch flow. See:
+#   https://github.com/fips-agents/fips-agents-cli/issues/45
+
+schema_version: 1
+
+patch:
+  categories:
+
+    chart:
+      description: Helm chart templates and ACM policies
+      patterns:
+        - chart/templates/**/*
+        - chart/Chart.yaml
+        - chart/README.md
+        - chart/policies/**/*
+      ask_before_patch: true
+
+    docs:
+      description: Documentation files
+      patterns:
+        - CLAUDE.md
+        - CONTRIBUTING.md
+        - SECURITY.md
+        - docs/**/*
+      ask_before_patch: false
+
+    build:
+      description: Build and deployment files
+      patterns:
+        - Makefile
+        - Containerfile
+        - .gitignore
+        - .gitleaks.toml
+      ask_before_patch: true
+
+  never_patch:
+    # The sandbox runtime — executor, guardrails, seccomp wiring, audit,
+    # pipeline, profiles. Users may have customized these and shouldn't
+    # be silently overwritten.
+    - sandbox/**
+    # User's tests
+    - tests/**/*.py
+    # User's deploy values (default + named profiles)
+    - chart/values.yaml
+    - chart/values-ctf.yaml
+    - chart/values-standalone.yaml
+    # User's project metadata
+    - pyproject.toml
+    - README.md
+    - LICENSE
+    # Environment files
+    - .env*
+    # Per-project repo settings (CODEOWNERS, CI workflows)
+    - .github/**


### PR DESCRIPTION
Net-new file at the repo root — does not touch anything PR #20 is changing, so safe to land independently.

## What

Adds \`.fips-template.yaml\` (\`schema_version: 1\`) declaring how \`fips-agents patch\` should treat this template. Three categories:

- \`chart\` — \`chart/templates/**/*\`, \`chart/Chart.yaml\`, \`chart/README.md\`, \`chart/policies/**/*\`. Ask before patch.
- \`docs\` — \`CLAUDE.md\`, \`CONTRIBUTING.md\`, \`SECURITY.md\`, \`docs/**/*\`. No prompt.
- \`build\` — \`Makefile\`, \`Containerfile\`, \`.gitignore\`, \`.gitleaks.toml\`. Ask before patch.

Plus a 10-entry \`never_patch\` list:

- \`sandbox/**\` — the runtime (executor, guardrails, seccomp, audit, pipeline, profiles).
- \`tests/**/*.py\` — user tests.
- \`chart/values.yaml\`, \`chart/values-ctf.yaml\`, \`chart/values-standalone.yaml\` — user deploy values for default / CTF / standalone profiles.
- \`pyproject.toml\`, \`README.md\`, \`LICENSE\` — user-owned project metadata.
- \`.env*\` — environment files.
- \`.github/**\` — per-project repo settings.

## Why

Without this file, scaffolded sandbox projects today get a clean ✗ error from \`fips-agents patch check\` (post fips-agents/fips-agents-cli#50, shipped in v0.12.1) telling them sandbox isn't patchable until the template ships a manifest. After this PR merges and a sandbox project is re-scaffolded (or an existing one runs \`patch check\` against the new template), the patch flow works for chart / docs / build drift.

## Conservative defaults — sandbox runtime is NEVER_PATCH

\`sandbox/**/*.py\` is in \`never_patch\` on the agent-template precedent: users may have customized the executor, guardrails, or seccomp wiring, and we don't silently overwrite their changes. If we later decide users SHOULD track upstream runtime changes via patch, that's a follow-up adding a \`runtime\` category with \`ask_before_patch: true\`.

## Compatibility

- Older fips-agents-cli installs (pre v0.12.0) ignore the file — nothing breaks.
- Newer installs (v0.12.0+) read it instead of falling through to the no-manifest error path.
- This PR only adds a new file, no existing files modified, so it does not conflict with PR #20 or any other in-flight work.

## Test plan

- [x] Manifest parses cleanly through \`fips_agents_cli.tools.patching._load_template_manifest\` and \`_categories_from_manifest\` (validated locally).
- [x] \`_resolve_categories\` returns the manifest's categories for project_type='sandbox' instead of raising \`PatchUnsupportedForProjectType\`.
- [x] No secrets detected by gitleaks.
- [ ] After merge: re-scaffold a sandbox project with \`fips-agents create sandbox\` and confirm \`patch check\` reports drift in chart/docs/build categories without surfacing \`sandbox/**\` or \`tests/**\`.